### PR TITLE
Add "yes/no" and  "multiple choice" question types in the survey creator

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -43,6 +43,8 @@
             "required": "Required",
             "singleChoice": "Single choice",
             "linearScale": "Linear scale",
+            "yesNo": "Yes/No",
+            "multipleChoice": "Multiple choice",
             "contentNotEmptyError": "Field cannot be empty",
             "contentLenError": "Field cannot be longer than 250 characters"
         },

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -43,6 +43,8 @@
             "required": "Wymagane",
             "singleChoice": "Jednokrotny wybór",
             "linearScale": "Skala liniowa",
+            "yesNo": "Tak/Nie",
+            "multipleChoice": "Wielokrotny wybór",
             "contentNotEmptyError": "Pole nie może być puste",
             "contentLenError": "Pole nie może być dłuższe niż 250 znaków"
         },

--- a/src/core/mappers/create.survey.mapper.ts
+++ b/src/core/mappers/create.survey.mapper.ts
@@ -49,7 +49,9 @@ export class CreateSurveyMapper implements Mapper<CreateSurveyModel, CreateSurve
             required: source.isRequired,
         };
 
-        if (source.type == QuestionType.SINGLE_TEXT_SELECTION){
+        if (source.type == QuestionType.SINGLE_TEXT_SELECTION
+            || source.type == QuestionType.MULTIPLE_CHOICE
+        ){
             question.options = [];
             source.options.forEach((option, index) => {
                 question.options!.push(this.mapOption(option, index));

--- a/src/domain/models/question.type.ts
+++ b/src/domain/models/question.type.ts
@@ -1,4 +1,6 @@
 export enum QuestionType{
     SINGLE_TEXT_SELECTION = "single_text_selection",
-    DISCRETE_NUMBER_SELECTION = "discrete_number_selection"
+    DISCRETE_NUMBER_SELECTION = "discrete_number_selection",
+    YES_NO_SELECTION = "yes_no_selection",
+    MULTIPLE_CHOICE = "multiple_choice"
 }

--- a/src/presentation/modules/app/components/create-question/create-question.component.html
+++ b/src/presentation/modules/app/components/create-question/create-question.component.html
@@ -32,7 +32,7 @@
         <mat-card-content>
             <app-create-text-selection-options [options]="question!.options"
             [sectionsToBeTriggered]="sectionsToBeTriggered"
-            *ngIf="question!.type == QuestionType.SINGLE_TEXT_SELECTION"/>
+            *ngIf="question!.type == QuestionType.SINGLE_TEXT_SELECTION || question!.type == QuestionType.MULTIPLE_CHOICE"/>
             <app-create-number-range *ngIf="question!.type == QuestionType.DISCRETE_NUMBER_SELECTION"
             [model]="question!.numberRange" [sectionsToBeTriggered]="sectionsToBeTriggered"/>
         </mat-card-content>

--- a/src/presentation/modules/app/components/create-question/create-question.component.ts
+++ b/src/presentation/modules/app/components/create-question/create-question.component.ts
@@ -29,17 +29,23 @@ export class CreateQuestionComponent {
 
   allQuestionTypes = [
     QuestionType.SINGLE_TEXT_SELECTION,
-    QuestionType.DISCRETE_NUMBER_SELECTION
+    QuestionType.DISCRETE_NUMBER_SELECTION,
+    QuestionType.YES_NO_SELECTION,
+    QuestionType.MULTIPLE_CHOICE
   ];
 
   questionTypeIconSelector = {
     [QuestionType.SINGLE_TEXT_SELECTION]: 'radio_button_checked',
-    [QuestionType.DISCRETE_NUMBER_SELECTION]: 'linear_scale'
+    [QuestionType.DISCRETE_NUMBER_SELECTION]: 'linear_scale',
+    [QuestionType.YES_NO_SELECTION]: 'check',
+    [QuestionType.MULTIPLE_CHOICE]: 'check_box'
   };
 
   questionTypeDisplay = {
     [QuestionType.SINGLE_TEXT_SELECTION]: 'createSurvey.createQuestion.singleChoice',
-    [QuestionType.DISCRETE_NUMBER_SELECTION]: 'createSurvey.createQuestion.linearScale'
+    [QuestionType.DISCRETE_NUMBER_SELECTION]: 'createSurvey.createQuestion.linearScale',
+    [QuestionType.YES_NO_SELECTION]: 'createSurvey.createQuestion.yesNo',
+    [QuestionType.MULTIPLE_CHOICE]: 'createSurvey.createQuestion.multipleChoice'
   };
 
   constructor(readonly translate: TranslateService){}


### PR DESCRIPTION
This pull request refers to https://dev.azure.com/survey-project/Survey/_boards/board/t/Survey%20Team/Issues/?workitem=78, there are more details in the description there.

ATTENTION
This contains a breaking change - the API is not prepared yet to understand introduced question types. Therefore, it will not work after merging until this is done. 

API "yes/no" question type ticket is here: https://dev.azure.com/survey-project/Survey/_boards/board/t/Survey%20Team/Issues/?workitem=77
For multiple choice it is planned to be done between 07/20/2024 and 08/03/2024 and a separate ticket will be created