### PR TITLE
update #75: localize calendar and save the selected lang

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -5,7 +5,11 @@
   "projects": {
     "survey-admin-panel": {
       "projectType": "application",
-      "schematics": {},
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss"
+        }
+      },
       "root": "",
       "sourceRoot": "src",
       "prefix": "app",
@@ -25,7 +29,8 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.scss"
+              "src/styles/styles.scss",
+              "src/styles/full.calendar.scss"
             ],
             "scripts": []
           },
@@ -84,7 +89,8 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.scss"
+              "src/styles/styles.scss",
+              "src/styles/full.calendar.scss"
             ],
             "scripts": []
           }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -99,7 +99,8 @@
             "create": "Add",
             "somethingWentWrong": "Something went wrong",
             "ok": "OK",
-            "createdSurveySendingPolicy": "Added survey sending policy"
+            "createdSurveySendingPolicy": "Added survey sending policy",
+            "dates": "Dates"
         },
         "surveyDetails": {
             "sendingPolicy": "Sending policy",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -99,7 +99,8 @@
             "create": "Dodaj",
             "somethingWentWrong": "Cos poszło nie tak",
             "ok": "OK",
-            "createdSurveySendingPolicy": "Dodano politykę wysyłania ankiety"
+            "createdSurveySendingPolicy": "Dodano politykę wysyłania ankiety",
+            "dates": "Daty"
         },
         "surveyDetails": {
             "sendingPolicy": "Polityka wysyłania",

--- a/src/core/services/local.storage.ts
+++ b/src/core/services/local.storage.ts
@@ -1,0 +1,28 @@
+import { Injectable } from "@angular/core";
+
+export interface LocalStorageService{
+    get<T>(key: string): T | null;
+    save<T>(key: string, value: T): void;
+}
+
+@Injectable()
+export class CookieStorageService implements LocalStorageService{
+
+
+    get<T>(key: string): T | null {
+        const cookies = document.cookie.split('; ');
+        for (const cookie of cookies) {
+            const [cookieKey, cookieValue] = cookie.split('=');
+            if (cookieKey === key) {
+            return JSON.parse(decodeURIComponent(cookieValue)) as T;
+        }
+        }
+        return null;
+    }
+
+
+    save<T>(key: string, value: T): void {
+        const serializedValue = encodeURIComponent(JSON.stringify(value));
+        document.cookie = `${key}=${serializedValue}; path=/;`;
+    }   
+}

--- a/src/presentation/modules/app/app.module.ts
+++ b/src/presentation/modules/app/app.module.ts
@@ -152,7 +152,7 @@ export function HttpLoaderFactory(http: HttpClient){
     {provide: 'createSurveySendingPolicyMapper', useClass: CreateSurveySendingPolicyMapper},
     {provide: 'surveySendingPolicyService', useClass: SurveySendingPolicyServiceImpl},
     {provide: 'summariesService', useClass: SummariesServiceImpl},
-    {provide: 'respondentDataService', useClass: RespondentDataServiceImpl}
+    {provide: 'respondentDataService', useClass: RespondentDataServiceImpl},
     {provide: 'storage', useClass: CookieStorageService}
   ],
 })

--- a/src/presentation/modules/app/app.module.ts
+++ b/src/presentation/modules/app/app.module.ts
@@ -58,6 +58,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { RespondentDataServiceImpl } from '../../../core/services/respondent.data.service.impl';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ENGLISH_DATE_FORMATS } from './date.formats';
+import { CookieStorageService } from '../../../core/services/local.storage';
 
 
 export const routes: Routes = [
@@ -152,6 +153,7 @@ export function HttpLoaderFactory(http: HttpClient){
     {provide: 'surveySendingPolicyService', useClass: SurveySendingPolicyServiceImpl},
     {provide: 'summariesService', useClass: SummariesServiceImpl},
     {provide: 'respondentDataService', useClass: RespondentDataServiceImpl}
+    {provide: 'storage', useClass: CookieStorageService}
   ],
 })
 export class AppModule {

--- a/src/presentation/modules/app/app.module.ts
+++ b/src/presentation/modules/app/app.module.ts
@@ -57,6 +57,7 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { RespondentDataServiceImpl } from '../../../core/services/respondent.data.service.impl';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ENGLISH_DATE_FORMATS } from './date.formats';
 
 
 export const routes: Routes = [
@@ -70,17 +71,7 @@ export const routes: Routes = [
     {path: 'summaries', component: SurveysListResultsComponent}
 ];
 
-export const POLISH_DATE_FORMATS = {
-  parse: {
-    dateInput: 'DD.MM.YYYY',
-  },
-  display: {
-    dateInput: 'DD.MM.YYYY',
-    monthYearLabel: 'MMMM YYYY',
-    dateA11yLabel: 'LL',
-    monthYearA11yLabel: 'MMMM YYYY'
-  },
-};
+
 
 export function HttpLoaderFactory(http: HttpClient){
   return new TranslateHttpLoader(http, '/assets/i18n/', '.json');
@@ -155,12 +146,14 @@ export function HttpLoaderFactory(http: HttpClient){
     {provide: 'surveyMapper', useClass: CreateSurveyMapper},
     {provide: 'surveyService', useClass: SurveyServiceImpl},
     {provide: 'respondentGroupsService', useClass: RespondentGroupsServiceImpl},
-    { provide: MAT_DATE_LOCALE, useValue: 'pl-PL' },
-    { provide: MAT_DATE_FORMATS, useValue: POLISH_DATE_FORMATS },
+    { provide: MAT_DATE_LOCALE, useValue: 'en-US' },
+    { provide: MAT_DATE_FORMATS, useValue: ENGLISH_DATE_FORMATS },
     {provide: 'createSurveySendingPolicyMapper', useClass: CreateSurveySendingPolicyMapper},
     {provide: 'surveySendingPolicyService', useClass: SurveySendingPolicyServiceImpl},
     {provide: 'summariesService', useClass: SummariesServiceImpl},
     {provide: 'respondentDataService', useClass: RespondentDataServiceImpl}
   ],
 })
-export class AppModule {}
+export class AppModule {
+
+}

--- a/src/presentation/modules/app/components/app/app.component.ts
+++ b/src/presentation/modules/app/components/app/app.component.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { DateAdapter } from 'chart.js';
 import { Subscription } from 'rxjs';
 import { ENGLISH_DATE_FORMATS, POLISH_DATE_FORMATS } from '../../date.formats';
+import { LocalStorageService } from '../../../../../core/services/local.storage';
 
 @Component({
   selector: 'app-root',
@@ -23,10 +24,11 @@ export class AppComponent implements OnDestroy {
   constructor(private readonly _router: Router,
     private readonly translateService: TranslateService,
     @Inject(MAT_DATE_LOCALE) dateLocale: string,
-    @Inject(MAT_DATE_FORMATS) matDateFormats: any) {
+    @Inject(MAT_DATE_FORMATS) matDateFormats: any,
+    @Inject('storage') storage: LocalStorageService) {
       translateService.addLangs(['en', 'pl']);
-      const browserLang = translateService.getBrowserLang();
-      translateService.use(browserLang?.match(/en|pl/) ? browserLang : 'en');
+      const lang = storage.get<string>('lang') ?? translateService.getBrowserLang();
+      translateService.use(lang?.match(/en|pl/) ? lang : 'en');
 
       this.langChangeSubscription = translateService.onLangChange.subscribe((event) => {
         const lang = event.lang;

--- a/src/presentation/modules/app/components/app/app.component.ts
+++ b/src/presentation/modules/app/components/app/app.component.ts
@@ -1,6 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, Inject, OnDestroy } from '@angular/core';
+import { MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
+import { DateAdapter } from 'chart.js';
+import { Subscription } from 'rxjs';
+import { ENGLISH_DATE_FORMATS, POLISH_DATE_FORMATS } from '../../date.formats';
 
 @Component({
   selector: 'app-root',
@@ -8,18 +12,35 @@ import { TranslateService } from '@ngx-translate/core';
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   title = 'survey-admin-panel';
 
   private readonly _pagesWithoutDashboard: string[] = [
     '/login'
   ]
+  private readonly langChangeSubscription: Subscription;
 
   constructor(private readonly _router: Router,
-    private readonly translateService: TranslateService){
+    private readonly translateService: TranslateService,
+    @Inject(MAT_DATE_LOCALE) dateLocale: string,
+    @Inject(MAT_DATE_FORMATS) matDateFormats: any) {
       translateService.addLangs(['en', 'pl']);
       const browserLang = translateService.getBrowserLang();
       translateService.use(browserLang?.match(/en|pl/) ? browserLang : 'en');
+
+      this.langChangeSubscription = translateService.onLangChange.subscribe((event) => {
+        const lang = event.lang;
+        if (lang === 'pl'){
+          dateLocale = 'pl-PL';
+          matDateFormats = POLISH_DATE_FORMATS
+        } else{
+          dateLocale = 'en-US';
+          matDateFormats = ENGLISH_DATE_FORMATS;
+        }
+      });
+  }
+  ngOnDestroy(): void {
+    this.langChangeSubscription.unsubscribe();
   }
 
   shouldDisplayDashboard(): boolean{

--- a/src/presentation/modules/app/components/create-survey-sending-policy/create-survey-sending-policy.component.html
+++ b/src/presentation/modules/app/components/create-survey-sending-policy/create-survey-sending-policy.component.html
@@ -7,7 +7,7 @@
       </mat-card-title>
       <mat-card-content>
           <mat-form-field>
-            <ngx-multiple-dates [matDatepicker]="picker" placeholder="Daty"
+            <ngx-multiple-dates [matDatepicker]="picker" [placeholder]="'surveyDetails.createSurveySendingPolicy.dates' | translate"
                                 [(ngModel)]="model.dates" [errorStateMatcher]="datesErrorStateMatcher">
             </ngx-multiple-dates>
             <mat-datepicker-toggle matPrefix [for]="picker"></mat-datepicker-toggle>

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.css
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.css
@@ -46,3 +46,10 @@ mat-toolbar span{
 .spacer{
     flex-grow: 1;
 }
+
+/* This is a workaround, because mat-icon-button does not  center the icon vertically.
+After changing mat-icon-button to mat-button it is properly centered, but the button is too wide.
+This was the only solution I found*/
+.hamburger mat-icon{
+    margin-top: -7px;
+}

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.css
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.css
@@ -32,14 +32,21 @@ mat-toolbar span{
     font-size: 20px;
 }
 
+mat-toolbar mat-form-field{
+    /* I really cannot center this in a better way, it just does not react on any 'center' css property*/
+    margin-top: 20px;
+    width: 150px;
+}
+
 .flag-and-text {
     display: flex;
     align-items: center;
+    font-size: 15px;
 }
 
 .flag {
     margin-right: 8px; 
-    width: 20px;
+    width: 15px;
     height: auto;
 }
 

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.html
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.html
@@ -13,7 +13,7 @@
               src="assets/imgs/flags/{{ language }}.svg"
               alt="{{ language }} flag"
             />
-            <span>{{ langageDisplayMappings[language] }}</span>
+            <span class="lang-span">{{ langageDisplayMappings[language] }}</span>
           </span>
         </mat-select-trigger>
         <mat-option *ngFor="let lang of availableLanguages" [value]="lang">

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.html
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.html
@@ -1,28 +1,33 @@
 <mat-toolbar color="primary" class="toolbar">
-    <button
-    mat-icon-button
-    class="hamburger"
-    (click)="toggleDrawer()">
-      <mat-icon>menu</mat-icon>
+  <button mat-icon-button class="hamburger" (click)="toggleDrawer()">
+    <mat-icon>menu</mat-icon>
   </button>
   <span>UrbEaT</span>
   <span class="spacer"></span>
-  <mat-form-field appearance="fill">
-    <mat-select [(value)]="language">
-      <mat-select-trigger>
-        <span class="flag-and-text">
-          <img class="flag" src="assets/imgs/flags/{{ language }}.svg" alt="{{ language }} flag"/>
-          <span>{{ langageDisplayMappings[language] }}</span>
-      </span>
-      </mat-select-trigger>
-      <mat-option *ngFor="let lang of availableLanguages" [value]="lang">
-        <span class="flag-and-text">
-            <img class="flag" src="assets/imgs/flags/{{ lang }}.svg" alt="{{ lang }} flag"/>
+    <mat-form-field appearance="fill">
+      <mat-select [(value)]="language">
+        <mat-select-trigger>
+          <span class="flag-and-text">
+            <img
+              class="flag"
+              src="assets/imgs/flags/{{ language }}.svg"
+              alt="{{ language }} flag"
+            />
+            <span>{{ langageDisplayMappings[language] }}</span>
+          </span>
+        </mat-select-trigger>
+        <mat-option *ngFor="let lang of availableLanguages" [value]="lang">
+          <span class="flag-and-text">
+            <img
+              class="flag"
+              src="assets/imgs/flags/{{ lang }}.svg"
+              alt="{{ lang }} flag"
+            />
             <span>{{ langageDisplayMappings[lang] }}</span>
-        </span>
-    </mat-option>
-    </mat-select>
-  </mat-form-field>
+          </span>
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
 </mat-toolbar>
 <mat-drawer-container class="container">
   <mat-drawer mode="side" [opened]="isDrawerOpen">

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.html
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.html
@@ -1,11 +1,9 @@
 <mat-toolbar color="primary" class="toolbar">
-  <button
+    <button
     mat-icon-button
-    class="example-icon"
-    aria-label="Example icon-button with menu icon"
-    (click)="toggleDrawer()"
-  >
-    <mat-icon>menu</mat-icon>
+    class="hamburger"
+    (click)="toggleDrawer()">
+      <mat-icon>menu</mat-icon>
   </button>
   <span>UrbEaT</span>
   <span class="spacer"></span>

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.scss
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.scss
@@ -1,3 +1,5 @@
+@import "../../../../../styles/styles.scss";
+
 .vertical-middle{
     vertical-align: middle;
 }
@@ -59,4 +61,8 @@ After changing mat-icon-button to mat-button it is properly centered, but the bu
 This was the only solution I found*/
 .hamburger mat-icon{
     margin-top: -7px;
+}
+
+.lang-span{
+    color: $primary-color;
 }

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.ts
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.ts
@@ -42,7 +42,7 @@ export class DashboardComponent implements OnInit{
 
   readonly langageDisplayMappings: Record<string, string> = {
     ['en']: 'English',
-    ['pl']: 'polski'
+    ['pl']: 'Polski'
   };
 
   constructor(private translateService: TranslateService,

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.ts
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.ts
@@ -12,7 +12,7 @@ interface NavListItem {
   selector: 'app-dashboard',
   standalone: false,
   templateUrl: './dashboard.component.html',
-  styleUrl: './dashboard.component.css'
+  styleUrl: './dashboard.component.scss'
 })
 export class DashboardComponent implements OnInit{
   isDrawerOpen = true;

--- a/src/presentation/modules/app/components/dashboard/dashboard.component.ts
+++ b/src/presentation/modules/app/components/dashboard/dashboard.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { LocalStorageService } from '../../../../../core/services/local.storage';
 
 interface NavListItem {
   display: string;
@@ -44,7 +45,8 @@ export class DashboardComponent implements OnInit{
     ['pl']: 'polski'
   };
 
-  constructor(private translateService: TranslateService) {}
+  constructor(private translateService: TranslateService,
+    @Inject('storage')private readonly storage: LocalStorageService) {}
   ngOnInit(): void {
     this._language = this.translateService.currentLang;
   }
@@ -62,6 +64,7 @@ export class DashboardComponent implements OnInit{
   set language(value: string) {
     this._language = value;
     this.translateService.use(value);
+    this.storage.save('lang', value);
   }
 
   toggleDrawer(): void {

--- a/src/presentation/modules/app/components/survey-sending-policy/survey-sending-policy.component.ts
+++ b/src/presentation/modules/app/components/survey-sending-policy/survey-sending-policy.component.ts
@@ -42,6 +42,7 @@ export class SurveySendingPolicyComponent implements OnInit, OnDestroy{
   }
   
    ngOnInit(): void {
+    this.calendarOptions.locale = this.translate.currentLang === 'pl' ? plLocale : enLocale;
     this.loadExistingSendingPolicies();
    }
 

--- a/src/presentation/modules/app/date.formats.ts
+++ b/src/presentation/modules/app/date.formats.ts
@@ -1,0 +1,23 @@
+export const POLISH_DATE_FORMATS = {
+    parse: {
+      dateInput: 'DD.MM.YYYY',
+    },
+    display: {
+      dateInput: 'DD.MM.YYYY',
+      monthYearLabel: 'MMMM YYYY',
+      dateA11yLabel: 'LL',
+      monthYearA11yLabel: 'MMMM YYYY'
+    },
+};
+
+export const ENGLISH_DATE_FORMATS = {
+    parse: {
+      dateInput: 'MM/DD/YYYY',
+    },
+    display: {
+      dateInput: 'MM/DD/YYYY',
+      monthYearLabel: 'MM YYYY',
+      dateA11yLabel: 'MM/DD/YYYY',
+      monthYearA11yLabel: 'MM YYYY',
+    },
+};

--- a/src/styles/full.calendar.scss
+++ b/src/styles/full.calendar.scss
@@ -1,0 +1,14 @@
+@import "./styles.scss";
+
+
+.fc .fc-button-primary {
+    background-color: $primary-color !important;
+}
+  
+.fc-toolbar-title {
+    color: $primary-color;
+}
+  
+.fc-col-header-cell {
+    color: $primary-color;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -40,6 +40,7 @@ $my-palette: (
 
 $primary: mat.define-palette($my-palette, 500);
 $accent: mat.define-palette($my-palette, 100);
+$primary-color: #3E434F;
 
 $my-theme: mat.define-light-theme((
  color: (


### PR DESCRIPTION
This pr refers to https://dev.azure.com/survey-project/Survey/_boards/board/t/Survey%20Team/Issues/?workitem=75 and adds the following:
- the calendar in the survey sending policy screen is localized 
- the selected language is remembered for the browser