### PR TITLE
#83: load real respondents data to the admin panel

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -37,7 +37,9 @@
             "lifeSatisfactionColumnHeader": "Life satisfaction",
             "stressLevelColumnHeader": "Stress level",
             "qualityOfSleepColumnHeader": "Quality of sleep",
-            "refresh": "Refresh"
+            "refresh": "Refresh",
+            "nothingToDisplay": "Nothing to display",
+            "errorLoadingRespondents": "Oops... There was an error when loading respondents. Try again later."
         }
     },
     "createSurvey": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,4 +1,8 @@
 {
+    "componentless": {
+        "male": "male",
+        "female": "female"
+    },
     "app": {
         "login": {
             "username": "Username",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -36,7 +36,8 @@
             "medicationUseColumnHeader": "Medication use",
             "lifeSatisfactionColumnHeader": "Life satisfaction",
             "stressLevelColumnHeader": "Stress level",
-            "qualityOfSleepColumnHeader": "Quality of sleep"
+            "qualityOfSleepColumnHeader": "Quality of sleep",
+            "refresh": "Refresh"
         }
     },
     "createSurvey": {

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1,4 +1,8 @@
 {
+    "componentless": {
+        "male": "mężczyzna",
+        "female": "kobieta"
+    },
     "app": {
         "login":{
             "username": "Nazwa użytkownika",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -37,7 +37,9 @@
             "lifeSatisfactionColumnHeader": "Zadowolenie z życia",
             "stressLevelColumnHeader": "Poziom stresu",
             "qualityOfSleepColumnHeader": "Jakość snu",
-            "refresh": "Odśwież"
+            "refresh": "Odśwież",
+            "nothingToDisplay": "Brak respondentów do wyswietlenia",
+            "errorLoadingRespondents": "Ups... Wystąpił błąd. Spróbuj ponownie później."
         }
     },
     "createSurvey": {

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -36,7 +36,8 @@
             "medicationUseColumnHeader": "Przyjmowane leki",
             "lifeSatisfactionColumnHeader": "Zadowolenie z życia",
             "stressLevelColumnHeader": "Poziom stresu",
-            "qualityOfSleepColumnHeader": "Jakość snu"
+            "qualityOfSleepColumnHeader": "Jakość snu",
+            "refresh": "Odśwież"
         }
     },
     "createSurvey": {

--- a/src/core/services/respondent.data.service.impl.ts
+++ b/src/core/services/respondent.data.service.impl.ts
@@ -1,0 +1,55 @@
+import { forkJoin, map, Observable } from "rxjs";
+import { RespondentDataService } from "../../domain/external_services/respondent.data.servce";
+import { RespondentData } from "../../domain/models/respondent.data";
+import { RespondentInfoCollections } from "../../domain/models/respondent.info";
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { ApiService } from "./api.service";
+
+@Injectable()
+export class RespondentDataServiceImpl 
+extends ApiService 
+implements RespondentDataService{
+    private readonly infoEndpoints = [
+        'agecategories',
+        'occupationcategories',
+        'educationcategories',
+        'greeneryareacategories',
+        'medicationuse',
+        'healthconditions',
+        'stresslevels',
+        'lifesatisfaction',
+        'qualityofsleep'
+    ]
+
+    constructor(client: HttpClient){
+        super(client);
+    }
+
+    getRespondentInfoCollections(): Observable<RespondentInfoCollections> {
+        const pipes = this.infoEndpoints.map(e => {
+            return this.get(`/api/${e}`)
+        });
+
+        return forkJoin(pipes).pipe(
+            map(responses => {
+                return {
+                  ageCategories: responses[0],
+                  occupationCategories: responses[1],
+                  educationCategories: responses[2],
+                  greeneryAreaCategories: responses[3],
+                  medicationUses: responses[4],
+                  healthConditions: responses[5],
+                  stressLevels: responses[6],
+                  lifeSatisfactions: responses[7],
+                  qualityOfSleeps: responses[8]
+                } as RespondentInfoCollections;
+              })
+        )
+    }
+
+    getRespondents(): Observable<RespondentData[]> {
+        return this.get('/api/respondents/all');
+    }
+    
+}

--- a/src/domain/external_services/respondent.data.servce.ts
+++ b/src/domain/external_services/respondent.data.servce.ts
@@ -1,0 +1,8 @@
+import { Observable } from "rxjs";
+import { RespondentInfoCollections } from "../models/respondent.info";
+import { RespondentData } from "../models/respondent.data";
+
+export interface RespondentDataService{
+    getRespondentInfoCollections(): Observable<RespondentInfoCollections>;
+    getRespondents(): Observable<RespondentData[]>;
+}

--- a/src/domain/models/respondent.data.ts
+++ b/src/domain/models/respondent.data.ts
@@ -1,0 +1,12 @@
+export interface RespondentData{
+    username: number;
+    gender: number;
+    ageCategoryId: number;
+    occupationCategoryId: number;
+    educationCategoryId: number;
+    healthStatusId: number;
+    medicationUseId: number;
+    lifeSatisfactionId: number;
+    stressLevelId: number;
+    qualityOfSleepId: number;
+}

--- a/src/domain/models/respondent.info.ts
+++ b/src/domain/models/respondent.info.ts
@@ -1,0 +1,56 @@
+export interface RespondentInfo{
+    id: number,
+    display: string
+}
+
+export interface RespondentInfoCollections{
+    ageCategories: RespondentInfo[],
+    occupationCategories: RespondentInfo[]
+    educationCategories: RespondentInfo[]
+    greeneryAreaCategories: RespondentInfo[]
+    medicationUses: RespondentInfo[]
+    healthConditions: RespondentInfo[]
+    stressLevels: RespondentInfo[]
+    lifeSatisfactions: RespondentInfo[]
+    qualityOfSleeps: RespondentInfo[]
+}
+
+export interface RespondentInfoValueDisplayMappings{
+    ageCategoriesMapping: Map<number, string>,
+    occupationCategoriesMapping: Map<number, string>,
+    educationCategoriesMapping: Map<number, string>,
+    greeneryAreaCategoriesMapping: Map<number, string>,
+    medicationUsesMapping: Map<number, string>,
+    healthConditionsMapping: Map<number, string>,
+    stressLevelsMapping: Map<number, string>,
+    lifeSatisfactionsMapping: Map<number, string>,
+    qualityOfSleepsMapping: Map<number, string>   
+}
+
+export const getMapForProperty = (property: string, mappings: RespondentInfoValueDisplayMappings): Map<number, string> | undefined =>{
+    if (property === 'ageCategoryId') return mappings.ageCategoriesMapping;
+    if (property === 'occupationCategoryId') return mappings.occupationCategoriesMapping;
+    if (property === 'educationCategoryId') return mappings.educationCategoriesMapping;
+    if (property === 'greeneryAreaCategoryId') return mappings.greeneryAreaCategoriesMapping;
+    if (property === 'medicationUseId') return mappings.medicationUsesMapping;
+    if (property === 'healthConditionId') return mappings.healthConditionsMapping;
+    if (property === 'stressLevelId') return mappings.stressLevelsMapping;
+    if (property === 'lifeSatisfactionId') return mappings.lifeSatisfactionsMapping;
+    if (property === 'qualityOfSleepId') return mappings.qualityOfSleepsMapping;
+
+    return undefined;
+}
+
+export const convertToValueDisplayMappings = (collections: RespondentInfoCollections): RespondentInfoValueDisplayMappings =>{
+    return {
+        ageCategoriesMapping: new Map(collections.ageCategories.map(c => [c.id, c.display])),
+        occupationCategoriesMapping: new Map(collections.occupationCategories.map(c => [c.id, c.display])),
+        educationCategoriesMapping: new Map(collections.educationCategories.map(c => [c.id, c.display])),
+        greeneryAreaCategoriesMapping: new Map(collections.greeneryAreaCategories.map(c => [c.id, c.display])),
+        medicationUsesMapping: new Map(collections.medicationUses.map(c => [c.id, c.display])),
+        healthConditionsMapping: new Map(collections.healthConditions.map(c => [c.id, c.display])),
+        stressLevelsMapping: new Map(collections.stressLevels.map(c => [c.id, c.display])),
+        lifeSatisfactionsMapping: new Map(collections.lifeSatisfactions.map(c => [c.id, c.display])),
+        qualityOfSleepsMapping: new Map(collections.qualityOfSleeps.map(c => [c.id, c.display]))
+    }
+}

--- a/src/presentation/modules/app/app.module.ts
+++ b/src/presentation/modules/app/app.module.ts
@@ -56,6 +56,7 @@ import { SurveySummaryTileComponent } from './components/survey-summary-tile/sur
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { RespondentDataServiceImpl } from '../../../core/services/respondent.data.service.impl';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 
 export const routes: Routes = [
@@ -121,7 +122,8 @@ export function HttpLoaderFactory(http: HttpClient){
         useFactory: HttpLoaderFactory,
         deps: [HttpClient]
       }
-    })
+    }),
+    MatProgressSpinnerModule
   ],
   declarations: [
     AppComponent, 

--- a/src/presentation/modules/app/app.module.ts
+++ b/src/presentation/modules/app/app.module.ts
@@ -55,6 +55,7 @@ import { SurveysListResultsComponent } from './components/surveys-list-results/s
 import { SurveySummaryTileComponent } from './components/survey-summary-tile/survey-summary-tile.component';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { RespondentDataServiceImpl } from '../../../core/services/respondent.data.service.impl';
 
 
 export const routes: Routes = [
@@ -156,7 +157,8 @@ export function HttpLoaderFactory(http: HttpClient){
     { provide: MAT_DATE_FORMATS, useValue: POLISH_DATE_FORMATS },
     {provide: 'createSurveySendingPolicyMapper', useClass: CreateSurveySendingPolicyMapper},
     {provide: 'surveySendingPolicyService', useClass: SurveySendingPolicyServiceImpl},
-    {provide: 'summariesService', useClass: SummariesServiceImpl}
+    {provide: 'summariesService', useClass: SummariesServiceImpl},
+    {provide: 'respondentDataService', useClass: RespondentDataServiceImpl}
   ],
 })
 export class AppModule {}

--- a/src/presentation/modules/app/components/buttons.ribbon/button.data.ts
+++ b/src/presentation/modules/app/components/buttons.ribbon/button.data.ts
@@ -1,4 +1,5 @@
 export interface ButtonData{
     content: string,
-    onClick: () => void
+    onClick: () => void,
+    icon?: string
 }

--- a/src/presentation/modules/app/components/buttons.ribbon/buttons.ribbon.component.css
+++ b/src/presentation/modules/app/components/buttons.ribbon/buttons.ribbon.component.css
@@ -4,3 +4,8 @@
     align-items: center;
     padding: 10px;
 }
+
+.buttons-panel > * + * 
+{
+     margin-left: 10px; 
+}

--- a/src/presentation/modules/app/components/buttons.ribbon/buttons.ribbon.component.html
+++ b/src/presentation/modules/app/components/buttons.ribbon/buttons.ribbon.component.html
@@ -1,6 +1,7 @@
 <div class="buttons-panel">
     <button *ngFor="let button of buttons" (click)="button.onClick()"
     mat-flat-button color="primary">
+        <mat-icon *ngIf="button.icon">{{ button.icon }} </mat-icon>
         {{ button.content | translate }}
     </button>
 </div>

--- a/src/presentation/modules/app/components/respondents/respondents.component.css
+++ b/src/presentation/modules/app/components/respondents/respondents.component.css
@@ -7,9 +7,14 @@
 
 .container{
     height: 100vh;
+    width: 100%;
 }
 
 .spacer{
     flex-grow: 1;
     margin-right: 10px;
+}
+
+.table-container{
+    text-align: center;
 }

--- a/src/presentation/modules/app/components/respondents/respondents.component.html
+++ b/src/presentation/modules/app/components/respondents/respondents.component.html
@@ -10,7 +10,8 @@
           {{ headerTranslationMappings[column] | translate }}
         </mat-header-cell>
         <mat-cell *matCellDef="let respondent">
-          {{ respondent[column] }}
+
+          {{ getActualCellDisplay(respondent, column) }}
         </mat-cell>
       </ng-container>
 

--- a/src/presentation/modules/app/components/respondents/respondents.component.html
+++ b/src/presentation/modules/app/components/respondents/respondents.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <app-buttons-ribbon [buttons]="ribbonButtons"/>
   <div class="table-container">
-    <mat-table [dataSource]="dataSource!" matSort class="mat-elevation-z8">
+    <mat-table [dataSource]="dataSource!" matSort class="mat-elevation-z8" *ngIf="respondents.length > 0">
       <ng-container
         *ngFor="let column of headers"
         [matColumnDef]="column"
@@ -22,6 +22,14 @@
 
       <mat-row *matRowDef="let row; columns: headers"></mat-row>
     </mat-table>
+    <h3 *ngIf="!isBusy && respondents.length === 0 && !loadingErrorOccured">
+      {{ 'respondents.respondents.nothingToDisplay' | translate }}
+    </h3>
+    <mat-error *ngIf="!isBusy && respondents.length === 0 && loadingErrorOccured">
+      <h3>
+        {{ 'respondents.respondents.errorLoadingRespondents' | translate }}
+      </h3>
+    </mat-error>
   </div>
 
   <div class="paginator-container">

--- a/src/presentation/modules/app/components/respondents/respondents.component.ts
+++ b/src/presentation/modules/app/components/respondents/respondents.component.ts
@@ -18,10 +18,10 @@ import { finalize, forkJoin } from 'rxjs';
   styleUrl: './respondents.component.css'
 })
 export class RespondentsComponent 
-implements AfterViewInit, OnInit{
+implements AfterViewInit{
   @ViewChild(MatSort) sort?: MatSort;
   @ViewChild(MatPaginator) paginator?: MatPaginator;
-  dataSource: MatTableDataSource<RespondentData>;
+  dataSource: MatTableDataSource<RespondentData> = null!;
   readonly respondents: RespondentData[] = [];
   readonly headers = [
     'username',
@@ -69,10 +69,19 @@ implements AfterViewInit, OnInit{
   constructor(@Inject('dialog') private readonly _dialog: MatDialog,
     @Inject('respondentDataService')private readonly service: RespondentDataService,
     private readonly translate: TranslateService){
-      this.dataSource = new MatTableDataSource<RespondentData>(this.respondents);
   }
-  ngOnInit(): void {
+
+  ngAfterViewInit(): void {
     this.loadData();
+    if (this.dataSource) {
+      if (this.sort) {
+        this.dataSource.sort = this.sort;
+      }
+      if (this.paginator) {
+        this.dataSource.paginator = this.paginator;
+      }
+    }
+    this.dataSource = new MatTableDataSource<RespondentData>(this.respondents);
   }
 
   loadData(): void{
@@ -119,17 +128,6 @@ implements AfterViewInit, OnInit{
     ).subscribe(res => {
       (res as RespondentData[]).forEach(r => this.respondents.push(r));
     });
-  }
-
-  ngAfterViewInit(): void {
-    if (this.dataSource) {
-      if (this.sort) {
-        this.dataSource.sort = this.sort;
-      }
-      if (this.paginator) {
-        this.dataSource.paginator = this.paginator;
-      }
-    }
   }
 
   generateRespondentsAccounts(): void{

--- a/src/presentation/modules/app/components/respondents/respondents.component.ts
+++ b/src/presentation/modules/app/components/respondents/respondents.component.ts
@@ -55,7 +55,8 @@ implements AfterViewInit, OnInit{
   ribbonButtons: ButtonData[] = [
     {
       content: 'respondents.respondents.refresh',
-      onClick: this.loadData.bind(this)
+      onClick: this.loadData.bind(this),
+      icon: 'refresh'
     },
     {
       content: 'respondents.respondents.createRespondentsAccounts',

--- a/src/presentation/modules/app/components/respondents/respondents.component.ts
+++ b/src/presentation/modules/app/components/respondents/respondents.component.ts
@@ -1,23 +1,14 @@
-import { AfterViewInit, Component, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { AddRespondentsComponent } from '../add-respondents/add-respondents.component';
 import { ButtonData } from '../buttons.ribbon/button.data';
-
-interface RespondentData{
-  username: string;
-  gender: string;
-  ageCategory: string;
-  occupationCategory: string;
-  educationCategory: string;
-  healthStatus: string;
-  medicationUse: string;
-  lifeSatisfaction: string;
-  stressLevel: string;
-  qualityOfSleep: string;
-}
+import { RespondentData } from '../../../../../domain/models/respondent.data';
+import { RespondentDataService } from '../../../../../domain/external_services/respondent.data.servce';
+import { convertToValueDisplayMappings, getMapForProperty, RespondentInfoCollections, RespondentInfoValueDisplayMappings } from '../../../../../domain/models/respondent.info';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-respondents',
@@ -26,49 +17,40 @@ interface RespondentData{
   styleUrl: './respondents.component.css'
 })
 export class RespondentsComponent 
-implements AfterViewInit{
+implements AfterViewInit, OnInit{
   @ViewChild(MatSort) sort?: MatSort;
   @ViewChild(MatPaginator) paginator?: MatPaginator;
   dataSource?: MatTableDataSource<RespondentData>;
   respondents: RespondentData[] = [];
   readonly headers = [
     'username',
-    'sex',
-    'ageCategory',
-    'occupation',
-    'education',
-    'health',
-    'medication',
-    'lifeSatisfaction',
-    'stressLevel',
-    'qualityOfSleep'
+    'gender',
+    'ageCategoryId',
+    'occupationId',
+    'educationCategoryId',
+    'healthConditionId',
+    'medicationUseId',
+    'lifeSatisfactionId',
+    'stressLevelId',
+    'qualityOfSleepId'
   ];
-
   headerTranslationMappings: { [key: string]: string } = {
     'username': 'respondents.respondents.usernameColumnHeader',
-    'sex': 'respondents.respondents.sexColumnHeader',
-    'ageCategory': 'respondents.respondents.ageCategoryColumnHeader',
-    'occupation': 'respondents.respondents.occupationColumnHeader',
-    'education': 'respondents.respondents.educationColumnHeader',
-    'health': 'respondents.respondents.healthStatusColumnHeader',
-    'medication': 'respondents.respondents.medicationUseColumnHeader',
-    'lifeSatisfaction': 'respondents.respondents.lifeSatisfactionColumnHeader',
-    'stressLevel': 'respondents.respondents.stressLevelColumnHeader',
-    'qualityOfSleep': 'respondents.respondents.qualityOfSleepColumnHeader'
+    'gender': 'respondents.respondents.sexColumnHeader',
+    'ageCategoryId': 'respondents.respondents.ageCategoryColumnHeader',
+    'occupationCategoryId': 'respondents.respondents.occupationColumnHeader',
+    'educationCategoryId': 'respondents.respondents.educationColumnHeader',
+    'healthConditionId': 'respondents.respondents.healthStatusColumnHeader',
+    'medicationUseId': 'respondents.respondents.medicationUseColumnHeader',
+    'lifeSatisfactionId': 'respondents.respondents.lifeSatisfactionColumnHeader',
+    'stressLevelId': 'respondents.respondents.stressLevelColumnHeader',
+    'qualityOfSleepId': 'respondents.respondents.qualityOfSleepColumnHeader'
   }
-  
-
+  translatableColumns = new Set<string>(['gender']);
+  directDisplayColumns = new Set<string>(['username']);
   columnFilter: { [key: string]: string[] } = {};
- 
-  genders: string[] = ['Kobieta', 'Mężczyzna'];
-  ageCategories: string[] = ['50-59', '60-69', '70+'];
-  occupationCategories: string[] = ['Zatrudniony', 'Niezatrudniony'];
-  educationCategories: string[] = ['Podstawowe', 'Zawodowe', 'Średnie', 'Wyższe'];
-  healthStatuses: string[] = ['Dobry', 'Zły'];
-  medicationUses: string[] = ['Tak', 'Nie'];
-  lifeSatisfactions: string[] = ['Wysokie', 'Niskie'];
-  stressLevels: string[] = ['Niski', 'Wysoki'];
-  qualityOfSleeps: string[] = ['Niska', 'Wysoka'];
+  respondentInfos: RespondentInfoCollections = null!;
+  valueDisplayMappings: RespondentInfoValueDisplayMappings = null!;
 
   ribbonButtons: ButtonData[] = [
     {
@@ -77,9 +59,31 @@ implements AfterViewInit{
     }
   ]
 
-  constructor(@Inject('dialog') private readonly _dialog: MatDialog){
-    this.generateRespondents();
+  constructor(@Inject('dialog') private readonly _dialog: MatDialog,
+    @Inject('respondentDataService')private readonly service: RespondentDataService,
+    private readonly translate: TranslateService){
   }
+  ngOnInit(): void {
+    this.loadRespondentInfos();
+    this.loadRespondents();
+  }
+
+  private loadRespondentInfos(): void{
+    this.service.getRespondentInfoCollections()
+    .subscribe(res => {
+      this.respondentInfos = res;
+      this.valueDisplayMappings = convertToValueDisplayMappings(res);
+    });
+  }
+
+  private loadRespondents(): void{
+    this.service.getRespondents()
+    .subscribe(res => {
+      this.respondents = res;
+      this.dataSource = new MatTableDataSource<RespondentData>(this.respondents);
+    });
+  }
+
   ngAfterViewInit(): void {
     if (this.dataSource) {
       if (this.sort) {
@@ -91,36 +95,23 @@ implements AfterViewInit{
     }
   }
 
-  generateRandomRespondent(): RespondentData {
-    return {
-      username: `User${Math.floor(Math.random() * 10000)}`,
-      gender: this.genders[Math.floor(Math.random() * this.genders.length)],
-      ageCategory: this.ageCategories[Math.floor(Math.random() * this.ageCategories.length)],
-      occupationCategory: this.occupationCategories[Math.floor(Math.random() * this.occupationCategories.length)],
-      educationCategory: this.educationCategories[Math.floor(Math.random() * this.educationCategories.length)],
-      healthStatus: this.healthStatuses[Math.floor(Math.random() * this.healthStatuses.length)],
-      medicationUse: this.medicationUses[Math.floor(Math.random() * this.medicationUses.length)],
-      lifeSatisfaction: this.lifeSatisfactions[Math.floor(Math.random() * this.lifeSatisfactions.length)],
-      stressLevel: this.stressLevels[Math.floor(Math.random() * this.stressLevels.length)],
-      qualityOfSleep: this.qualityOfSleeps[Math.floor(Math.random() * this.qualityOfSleeps.length)],
-    };
-  }
-
-  generateRespondents(): void {
-    this.respondents = [];
-    for (let i = 0; i < 100; i++) {
-      this.respondents.push(this.generateRandomRespondent());
-    }
-    this.dataSource = new MatTableDataSource(this.respondents);
-    this.dataSource.sort = this.sort!;
-    this.dataSource.paginator = this.paginator!;
-  }
-
   generateRespondentsAccounts(): void{
     this._dialog.open(AddRespondentsComponent, {
       hasBackdrop: true,
       closeOnNavigation: false
     })
+  }
+
+  getActualCellDisplay(respondent: RespondentData, columnName: string): string | undefined{
+    if (this.translatableColumns.has(columnName)){
+      return this.translate.instant(`componentless.${(respondent as any)[columnName]}`);
+    }
+
+    if (this.directDisplayColumns.has(columnName)){
+      return (respondent as any)[columnName];
+    }
+
+    return getMapForProperty(columnName, this.valueDisplayMappings)?.get((respondent as any)[columnName]);
   }
 
 }

--- a/src/presentation/modules/app/components/respondents/respondents.component.ts
+++ b/src/presentation/modules/app/components/respondents/respondents.component.ts
@@ -54,18 +54,26 @@ implements AfterViewInit, OnInit{
 
   ribbonButtons: ButtonData[] = [
     {
+      content: 'respondents.respondents.refresh',
+      onClick: this.loadData.bind(this)
+    },
+    {
       content: 'respondents.respondents.createRespondentsAccounts',
       onClick: this.generateRespondentsAccounts.bind(this)
     }
-  ]
+  ];
 
   constructor(@Inject('dialog') private readonly _dialog: MatDialog,
     @Inject('respondentDataService')private readonly service: RespondentDataService,
     private readonly translate: TranslateService){
   }
   ngOnInit(): void {
-    this.loadRespondentInfos();
+    this.loadData();
+  }
+
+  loadData(): void{
     this.loadRespondents();
+    this.loadRespondentInfos();
   }
 
   private loadRespondentInfos(): void{


### PR DESCRIPTION
This pr is related to: https://dev.azure.com/survey-project/Survey/_boards/board/t/Survey%20Team/Issues/?workitem=83

It loads all respondents on the "Respondents" page. Also note, that currently "username" won't be displayed until this pull request https://github.com/projekt-inzynierski/survey-api/pull/40 is merged in the API project. But this does not have to wait for this, it'll just display an empty cell instead of a username. 

Remember about the squash, as this contains few commits 