### PR TITLE
#84: allow the option to turn on only later section

### DIFF
--- a/src/core/models/section.to.be.triggered.ts
+++ b/src/core/models/section.to.be.triggered.ts
@@ -1,4 +1,5 @@
 export interface SectionToBeTriggered{
     sectionNumber: number,
-    name?: string
+    name?: string,
+    guid: string
 }

--- a/src/core/utils/guid.spec.ts
+++ b/src/core/utils/guid.spec.ts
@@ -1,0 +1,15 @@
+import { generateGuid } from "./guid";
+
+describe('generateGuid', () => {
+    it('should generate a valid GUID', () => {
+        const guid = generateGuid();
+        const guidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+        expect(guid).toMatch(guidPattern);
+    });
+
+    it('should generate a unique GUID each time', () => {
+        const guid1 = generateGuid();
+        const guid2 = generateGuid();
+        expect(guid1).not.toBe(guid2);
+    });
+});

--- a/src/core/utils/guid.ts
+++ b/src/core/utils/guid.ts
@@ -1,0 +1,11 @@
+export function generateGuid(): string {
+    const d = new Date().getTime();
+    const d2 = (performance && performance.now && (performance.now() * 1000)) || 0;
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+    return uuid;
+}
+  

--- a/src/core/utils/guid.ts
+++ b/src/core/utils/guid.ts
@@ -1,11 +1,12 @@
 export function generateGuid(): string {
-    const d = new Date().getTime();
-    const d2 = (performance && performance.now && (performance.now() * 1000)) || 0;
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      const r = Math.random() * 16;
-      const v = c === 'x' ? r : (r & 0x3 | 0x8);
-      return v.toString(16);
-    });
-    return uuid;
+  const template = 'xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx';
+  const guid = template.replace(/[xy]/g, (character) => {
+      const randomValue = Math.random() * 16 | 0;
+      const replacementValue = character === 'x'
+          ? randomValue
+          : (randomValue & 0x3 | 0x8);
+      return replacementValue.toString(16);
+  });
+  return guid;
 }
   

--- a/src/presentation/modules/app/components/create-section/create-section.component.html
+++ b/src/presentation/modules/app/components/create-section/create-section.component.html
@@ -54,7 +54,7 @@
             (addQuestionBelowEvent)="addQuestionBelow($event)"
             (removeEvent)="removeQuestion($event)"
             [question]="question"
-            [sectionsToBeTriggered]="sectionsToBeTriggered"/>
+            [sectionsToBeTriggered]="selectableSectionsToBeTriggered"/>
         </div>
         <mat-error *ngIf="questionsNumberError != null">{{ questionsNumberError }}></mat-error>
         <div class="wrap-panel">

--- a/src/presentation/modules/app/components/create-section/create-section.component.html
+++ b/src/presentation/modules/app/components/create-section/create-section.component.html
@@ -16,7 +16,7 @@
                 <mat-form-field appearance="fill">
                     <mat-label> {{ 'createSurvey.createSection.visibility' | translate  }} </mat-label>
                     <mat-select [(value)]="visibility">
-                      <mat-option *ngFor="let visibility of allVisibilities"
+                      <mat-option *ngFor="let visibility of selectableSectionVisibilities"
                       [value]="visibility">
                         {{ getVisibilityDisplay(visibility) }}
                       </mat-option>

--- a/src/presentation/modules/app/components/create-section/create-section.component.ts
+++ b/src/presentation/modules/app/components/create-section/create-section.component.ts
@@ -83,7 +83,6 @@ export class CreateSectionComponent {
   set name(value: string | undefined){
     if (this.section !== null){
       if (this.section.visibility == SectionVisibility.ANSWER_TRIGGERED){
-        //TO DO: what if we have more than one section with the same name?
         this.updateSectionToBeTriggered(value);
       }
       this.section.name = value;

--- a/src/presentation/modules/app/components/create-section/create-section.component.ts
+++ b/src/presentation/modules/app/components/create-section/create-section.component.ts
@@ -9,6 +9,7 @@ import { ErrorStateMatcher } from '@angular/material/core';
 import { FormlessErrorStateMatcher } from '../../../../utils/formless.error.state.matcher';
 import { SectionToBeTriggered } from '../../../../../core/models/section.to.be.triggered';
 import { TranslateService } from '@ngx-translate/core';
+import { generateGuid } from '../../../../../core/utils/guid';
 
 
 @Component({
@@ -32,6 +33,12 @@ export class CreateSectionComponent {
   nameError: string | null = null;
   questionsNumberError: string | null = null;
   sectionNameErrorStateMatcher: ErrorStateMatcher = new FormlessErrorStateMatcher(() => this.nameError);
+  //this guid is to identity the section in the editor, as possibly the user can create two with the same name before it is validated
+  guid = generateGuid();
+  
+  get selectableSectionsToBeTriggered(): SectionToBeTriggered[]{
+    return this.sectionsToBeTriggered.filter(section => section.sectionNumber > this.sectionNumber);
+  }
 
   get visibility(): SectionVisibility{
     return this.section?.visibility ?? SectionVisibility.ALWAYS;
@@ -45,12 +52,13 @@ export class CreateSectionComponent {
     if (this.section.visibility !== SectionVisibility.ANSWER_TRIGGERED && value === SectionVisibility.ANSWER_TRIGGERED){
       this.sectionsToBeTriggered.push({
         sectionNumber: this.sectionNumber,
-        name: this.section.name
+        name: this.section.name,
+        guid: this.guid
       });
     }
 
     if (this.section.visibility === SectionVisibility.ANSWER_TRIGGERED && value !== SectionVisibility.ANSWER_TRIGGERED){
-      const index = this.sectionsToBeTriggered.findIndex(section => section.name === this.section?.name);
+      const index = this.sectionsToBeTriggered.findIndex(section => section.guid === this.guid);
       if (index !== -1) {
         this.sectionsToBeTriggered.splice(index, 1);
       }   
@@ -76,7 +84,7 @@ export class CreateSectionComponent {
     if (this.section !== null){
       if (this.section.visibility == SectionVisibility.ANSWER_TRIGGERED){
         //TO DO: what if we have more than one section with the same name?
-        this.updateSectionToBeTriggered(this.section.name, value);
+        this.updateSectionToBeTriggered(value);
       }
       this.section.name = value;
     }
@@ -95,8 +103,8 @@ export class CreateSectionComponent {
     }
   }
 
-  updateSectionToBeTriggered(oldName: string | undefined, newName: string | undefined): void{
-    const idx = this.sectionsToBeTriggered.findIndex(section => section.name === oldName);
+  updateSectionToBeTriggered(newName: string | undefined): void{
+    const idx = this.sectionsToBeTriggered.findIndex(section => section.guid === this.guid);
     if (idx !== -1) {
       this.sectionsToBeTriggered[idx].name = newName;
     }

--- a/src/presentation/modules/app/components/create-section/create-section.component.ts
+++ b/src/presentation/modules/app/components/create-section/create-section.component.ts
@@ -77,7 +77,7 @@ export class CreateSectionComponent {
   ];
 
   get selectableSectionVisibilities(): SectionVisibility[]{
-    return this.sectionNumber === 0 ? [SectionVisibility.ALWAYS, SectionVisibility.GROUP_SPECIFIC]
+    return this.sectionNumber === 1 ? [SectionVisibility.ALWAYS, SectionVisibility.GROUP_SPECIFIC]
     : this.allVisibilities;
   }
 

--- a/src/presentation/modules/app/components/create-section/create-section.component.ts
+++ b/src/presentation/modules/app/components/create-section/create-section.component.ts
@@ -76,6 +76,11 @@ export class CreateSectionComponent {
     SectionVisibility.ANSWER_TRIGGERED
   ];
 
+  get selectableSectionVisibilities(): SectionVisibility[]{
+    return this.sectionNumber === 0 ? [SectionVisibility.ALWAYS, SectionVisibility.GROUP_SPECIFIC]
+    : this.allVisibilities;
+  }
+
   get name(): string | undefined{
     return this.section?.name;
   }


### PR DESCRIPTION
This pr refers to: https://dev.azure.com/survey-project/Survey/_boards/board/t/Survey%20Team/Issues/?workitem=84 and disables the option turning on the section that is earlier in the survey. 

Also, it contains a little bug fix: When the user creates two "answer triggered" sections with the same name, and turns on one of them with some option, and then changes one name, it was impossible to determine which section should be renamed. Now it works. 